### PR TITLE
[docs] Fix doc generation for external protobuf targets

### DIFF
--- a/go_proto/rules.bzl
+++ b/go_proto/rules.bzl
@@ -391,7 +391,7 @@ def _redoc_impl(ctx):
         command = "%s -pkg %s -prefix %s -o %s %s" % (
             ctx.executable.bindata.path,
             pkg,
-            "%s/%s" % (ctx.genfiles_dir.path, ctx.label.package),
+            ctx.outputs.bindata.dirname,
             ctx.outputs.bindata.path,
             " ".join([src.path for src in (ctx.files.srcs + redoc_pages + [index])]),
         ),


### PR DESCRIPTION
If the protobuf source is in a different workspace than the target the
prefix passed to go-bindata is incorrect. This uses the directory of the
output file as the prefix instead, which works for both local and
external sources.