### PR TITLE
Update protoc plugins and fix error code propagation

### DIFF
--- a/go_proto/rules.bzl
+++ b/go_proto/rules.bzl
@@ -145,7 +145,7 @@ def _proto_gen_impl(ctx):
         letmegrpc,
     ] + proto_path_args + [src.path for src in ctx.files.srcs])
 
-    cmd = protoc_cmd + ";" + ";".join(rename_cmds)
+    cmd = protoc_cmd + " && " + " && ".join(rename_cmds)
     ctx.action(
         inputs = inputs,
         outputs = outputs,

--- a/go_proto/rules.bzl
+++ b/go_proto/rules.bzl
@@ -623,7 +623,7 @@ def gogo_bindata_library(
     )
 
 _gogo_protobuf_repositories = {
-    "github.com/tnarg/protoc-go-plugins":     "4de2aa7f190b25cfcf73dabdd0ec167d690f6f4b",
+    "github.com/tnarg/protoc-go-plugins":     "5e0db29783e94a21c45bee0258f19cf55c81b019",
     #"github.com/gogo/letmegrpc":              "de2024216b825ffeca23577fc2bf5356a4f527fb",
     "github.com/gogo/protobuf":               "2adc21fd136931e0388e278825291678e1d98309",
     "github.com/golang/glog":                 "23def4e6c14b4da8ac2ed8007337bc5eb5007998",


### PR DESCRIPTION
 - Update protoc-go-plugins pointer

 - Propagate failure correctly
    
    Using ; as a separator between shell commands is brittle, because
    failure is not propagated correctly.  In the worst case, this could
    leave the external repository in a broken state.